### PR TITLE
Run GitHub Actions on windows-2019

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v4

--- a/Gu.Wpf.NumericInput.sln
+++ b/Gu.Wpf.NumericInput.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.87
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".sln", ".sln", "{29B0BA6F-9967-477B-9DC3-A605E9BAAB65}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,6 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".sln", ".sln", "{29B0BA6F-9
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		azure-pipelines.yml = azure-pipelines.yml
+		.github\workflows\ci.yml = .github\workflows\ci.yml
+		.github\dependabot.yml = .github\dependabot.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gu.Wpf.NumericInput", "Gu.Wpf.NumericInput\Gu.Wpf.NumericInput.csproj", "{5DB0DB61-0A77-4E44-9DD9-BEC53425EF60}"


### PR DESCRIPTION
It seems some automation APIs aren't working well on Windows 11 (thus locally), to trying with an older Windows runner.